### PR TITLE
Build error in examples fixed. Added <OD_BINARY_DIR>/bin dir to cmake.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
+file(MAKE_DIRECTORY ${OD_BINARY_DIR}/bin)
 add_subdirectory(objectdetector)
 add_subdirectory(apps)

--- a/examples/apps/CMakeLists.txt
+++ b/examples/apps/CMakeLists.txt
@@ -1,6 +1,6 @@
 OD_ADD_EXAMPLE(odcadrecog_test_single_model FILES cadrecog2D/od_test_single_db_single_model.cpp
                 LINK_WITH od_common od_local_image_detector)
-add_custom_command(TARGET odcadrecog_test_single_model POST_BUILD COMMAND cp odcadrecog_test_single_model /home/sarkar/libs/bin/)
+add_custom_command(TARGET odcadrecog_test_single_model POST_BUILD COMMAND cp odcadrecog_test_single_model ${OD_BINARY_DIR}/bin/)
 
 
 OD_ADD_EXAMPLE(od_multihog_app FILES global2D/od_multihog_app.cpp


### PR DESCRIPTION
Fixes https://github.com/krips89/opendetection/issues/3.

I added a cmake instruction to create a bin directory under OD_BINARY_DIR. And the binary outputs of example programs will be written to this directory.